### PR TITLE
update bert base config and README.md commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ The script optionally outputs a .json file with benchmark results and options us
 allowing the user to run multiple benchmark back-to-back, like:
 
 ```bash
-python benchmark.py -d tt -m bert -c tiny --task text_classification --save_output
+python benchmark.py -d tt -m bert -c base --task text_classification --save_output
 ```
 
 or
 
 ```bash
-python benchmark.py -d cuda -m bert -c tiny --task text_classification --save_output
+python benchmark.py -d cuda -m bert -c base --task text_classification --save_output
 ```
 
 To see which models and configurations are currently supported, run:

--- a/benchmark/models/bert/bert.py
+++ b/benchmark/models/bert/bert.py
@@ -36,7 +36,8 @@ def bert(training: bool, task: str, config: str, microbatch: int, device: str, d
         available_devices = pybuda.detect_available_devices()
         if available_devices[0] == BackendDevice.Grayskull:
             os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = f"{18*1024}"
-            pybuda.config.override_op_size("gelu_103", (3, 1))
+            if config == "large":
+                pybuda.config.override_op_size("gelu_103", (3, 1))
 
     # Set model parameters based on chosen task and model configuration
     if task == "na":


### PR DESCRIPTION
## change log

- update bert base config and README.md commands, only set gelu_103 opsize for bert large.

### Discussion

Fixes following compile issue when running bert base using benchmark.py:
```
~/benchmarking$ python benchmark.py -d tt -m bert -c base --task text_classification --save_output
...
2024-04-04 15:46:05.394 | INFO     | Always          - Running Balancer with Policy: PolicyType::Ribbon
2024-04-04 15:46:05.839 | FATAL    | Balancer        - Illegal grid shape chosen for op 'gelu_103' override, grid_shape: GridShape{.r = 3, .c = 1}
2024-04-04 15:46:05.843 | ERROR    | pybuda.device:run_next_command:469 - Compile error: Illegal grid shape chosen for op 'gelu_103' override, grid_shape: GridShape{.r = 3, .c = 1}
Traceback (most recent call last):
  File "/home/user/env/lib/python3.8/site-packages/pybuda/device.py", line 458, in run_next_command
    ret = self.compile_for(
  File "/home/user/env/lib/python3.8/site-packages/pybuda/ttdevice.py", line 820, in compile_for
    self._compile_output = pybuda_compile_from_context(compile_context)
  File "/home/user/env/lib/python3.8/site-packages/pybuda/compile.py", line 248, in pybuda_compile_from_context
    next_stage = stage_to_func[current_stage](context)
  File "/home/user/env/lib/python3.8/site-packages/pybuda/compile.py", line 947, in run_balancer_and_placer
    context.balancer_solution, had_balancer_attempts = run_placer_buda_passes(context.lowered_graph, balancer_config, context.fracture_chip_id_assignments, context.compiler_cfg.paddings)
RuntimeError: Illegal grid shape chosen for op 'gelu_103' override, grid_shape: GridShape{.r = 3, .c = 1}
```