### PR TITLE
Patch clean lint workflow -- remove deprecation warning

### DIFF
--- a/.github/workflows/clean-lint-style.yml
+++ b/.github/workflows/clean-lint-style.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -34,21 +34,19 @@ jobs:
           make style
 
       - name: Check if GPG key exists
-        id: check-gpg-key
         run: |
           if [ -n "${{ secrets.GPG_PRIVATE_KEY }}" ]; then
-            echo "::set-output name=key_exists::true"
+            echo "GPG_KEY_EXISTS=true" >> $GITHUB_ENV
           else
-            echo "::set-output name=key_exists::false"
+            echo "GPG_KEY_EXISTS=false" >> $GITHUB_ENV
           fi
 
       - name: Import GPG key if it exists
-        if: steps.check-gpg-key.outputs.key_exists == 'true'
-        id: import-gpg
+        if: env.GPG_KEY_EXISTS == 'true'
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE}}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
 
@@ -56,7 +54,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_user_name: CleanBot
-          commit_message: '*** AUTOMATED COMMIT | Applied Code Formatting and Cleanup ✨ 🍰 ✨***'
+          commit_message: '*** AUTOMATED COMMIT | Applied Code Formatting and Cleanup ✨🍰✨***'
           commit_user_email: aramchandran@tenstorrent.com
-          commit_options: ${{ steps.check-gpg-key.outputs.key_exists == 'true' && '-S' || '' }}
+          commit_options: ${{ env.GPG_KEY_EXISTS == 'true' && '-S' || '' }}
           branch: ${{ github.head_ref }}

--- a/.github/workflows/clean-lint-style.yml
+++ b/.github/workflows/clean-lint-style.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Install dependencies and run clean and lint
         run: |
           python -m venv venv
-          source venv/bin/activate && \
-          pip install --upgrade pip==24.0 && \
-          pip install -r requirements-dev.txt && \
-          make clean && \
-          make clean_tt && \
+          source venv/bin/activate
+          pip install --upgrade pip==24.0
+          pip install -r requirements-dev.txt
+          make clean
+          make clean_tt
           make style
 
       - name: Check if GPG key exists


### PR DESCRIPTION
The implementation of [PR#45](https://github.com/tenstorrent/benchmarking/pull/14) effectively addressed issues related to the unavailability of a GPG key, but with a deprecation warning during its run. This patch maintains the identical logical structure, substituting the `set-output` command for the utilization of `GITHUB_OUTPUT` environment files, as recommended in the [official guidance](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). 
All other logic and workflow executions remain unchanged.



Old workflow run with the warning:
![Screenshot 2024-04-09 at 4 18 09 PM](https://github.com/tenstorrent/benchmarking/assets/159844994/c8362b74-8744-443c-a873-39c5a091bd6a)


