### PR TITLE
Update version of black=24.4.0 to patch ReDoS vulnerability

### DIFF
--- a/benchmark/common/dataset_classes.py
+++ b/benchmark/common/dataset_classes.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import zipfile

--- a/benchmark/common/dataset_classes.py
+++ b/benchmark/common/dataset_classes.py
@@ -913,7 +913,7 @@ class BrainSegmentationDataset(Dataset):
 
         # finally get data per image not per patient
         self.data = []
-        for (patient_id, slice_id) in self.patient_slice_index[:n_samples]:
+        for patient_id, slice_id in self.patient_slice_index[:n_samples]:
             v, m = self.volumes[patient_id]
             # fix dimensions (C, H, W)
             image = v[slice_id].transpose(2, 0, 1)

--- a/benchmark/models/falcon/utils/pybudify.py
+++ b/benchmark/models/falcon/utils/pybudify.py
@@ -56,9 +56,9 @@ class PyBudify(torch.nn.Module):
 
             # pybuda workarounds
             os.environ["GOLDEN_WORMHOLE_B0"] = "1"  # golden should always simulate a B0 as that's all we use now
-            os.environ[
-                "PYBUDA_ENABLE_STABLE_SOFTMAX"
-            ] = "1"  # improved accuracy - pybuda team surprised we need it though
+            os.environ["PYBUDA_ENABLE_STABLE_SOFTMAX"] = (
+                "1"  # improved accuracy - pybuda team surprised we need it though
+            )
             os.environ["PYBUDA_CONVERT_PARAMS_TO_TVM"] = "0"  # faster compile times... why would this ever be 1?
             os.environ["TT_BACKEND_TIMEOUT"] = "0"  # default is too aggressive for large models?
 

--- a/benchmark/models/falcon/utils/pybudify.py
+++ b/benchmark/models/falcon/utils/pybudify.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/benchmark/models/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
+++ b/benchmark/models/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 # port of models described in RW

--- a/benchmark/models/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
+++ b/benchmark/models/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
@@ -766,12 +766,12 @@ class DecoderLayer(nn.Module):
 
         # replace mlp with padded
         padded_mlp = PaddedMLP(self.config)
-        padded_mlp.dense_h_to_4h.weight.data[
-            : 4 * unpadded_hidden, :unpadded_hidden
-        ] = self.mlp.dense_h_to_4h.weight.data
-        padded_mlp.dense_4h_to_h.weight.data[
-            :unpadded_hidden, : 4 * unpadded_hidden
-        ] = self.mlp.dense_4h_to_h.weight.data
+        padded_mlp.dense_h_to_4h.weight.data[: 4 * unpadded_hidden, :unpadded_hidden] = (
+            self.mlp.dense_h_to_4h.weight.data
+        )
+        padded_mlp.dense_4h_to_h.weight.data[:unpadded_hidden, : 4 * unpadded_hidden] = (
+            self.mlp.dense_4h_to_h.weight.data
+        )
         padded_mlp.make_pad_weights()
         self.mlp = padded_mlp
 
@@ -1184,7 +1184,7 @@ class RWModel(RWPreTrainedModel):
 
         if past_key_values is not None and attention_mask is not None:
             flattened_kv = []
-            for (k, v) in past_key_values:
+            for k, v in past_key_values:
                 flattened_kv.extend([k, v])
             # outputs = self.blocks(hidden_states, cos, sin, attention_mask, *flattened_kv)
             # import pdb; pdb.set_trace()

--- a/benchmark/models/open_pose/utils/common.py
+++ b/benchmark/models/open_pose/utils/common.py
@@ -77,6 +77,7 @@ def openpose_preprocess(dataset, target_height, target_width):
 
 # ---------------------------------------------------------------------------------------------------------------------
 
+
 # added coco evaluation functions
 def to_coco_json_format_batch(b_coco_keypoints, b_scores, b_image_ids):
     # always use category_id=1 for person

--- a/benchmark/models/whisper/whisper_impl.py
+++ b/benchmark/models/whisper/whisper_impl.py
@@ -115,9 +115,9 @@ def generate_model_whisper_enc_dec(variant):
     if pad_model:
         config.max_source_positions = padded_len
     else:
-        os.environ[
-            "PYBUDA_PAD_PARAMETER"
-        ] = f"model.model.encoder.embed_positions.weight, {padded_len}, {config.d_model}"
+        os.environ["PYBUDA_PAD_PARAMETER"] = (
+            f"model.model.encoder.embed_positions.weight, {padded_len}, {config.d_model}"
+        )
 
     max_length = config.max_length
     model = WhisperForConditionalGeneration.from_pretrained(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest==7.1.2
-black==22.3.0
+black==24.4.0
 flake8==3.9.2
 isort==5.10.1
 pre-commit==2.19.0


### PR DESCRIPTION
Versions of the package black before 24.3.0 are vulnerable to Regular Expression Denial of Service (ReDoS) via the lines_with_leading_tabs_expanded function in the strings.py file. An attacker could exploit this vulnerability by crafting a malicious input that causes a denial of service.